### PR TITLE
Fix: Use num_points instead of num_batch in loop range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.idea/
+*.iml
+__pycache__/
+*.pyc
+.DS_Store
+*.swp
+venv/
+.venv/

--- a/src/1_calculate_attribution_completion.py
+++ b/src/1_calculate_attribution_completion.py
@@ -100,7 +100,7 @@ def get_context_attr(idx, prompt_without_context, prompt_with_context, answer_ob
         for batch_idx in range(args.num_batch):
             grad = None
             all_grads = None
-            for i in range(0, args.batch_size, args.batch_size_per_inference):
+            for i in range(0, args.num_points, args.batch_size_per_inference):
                 # print(i, i + args.batch_size_per_inference)
                 batch_activations = scaled_activations[i: i + args.batch_size_per_inference] # (batch_size_per_inference, ffn_size)
                 batch_w_activations = w_ffn_activations.repeat(args.batch_size_per_inference, 1) # (batch_size_per_inference, ffn_size)


### PR DESCRIPTION
## Summary
This PR fixes a bug in the `get_context_attr` function where the loop range incorrectly uses `args.num_batch` instead of `args.num_points`, causing data to be skipped when `num_batch > 1`.

## Problem
As described in Issue #1, when computing Integrated Gradients (IG) using Riemann sum with `num_batch > 1`, only a portion of the data is processed while the rest is skipped.

### Example:
- **Case 1**: `num_batch = 1, batch_size = 20`
  - All 20 points processed correctly
  
- **Case 2**: `num_batch = 2, batch_size = 20`
  - ❌ Only indices 0~19 processed
  - ❌ Indices 20~39 skipped
  - Expected: All 40 points (0~39) should be processed

## Changes
- Changed loop range from `range(0, args.batch_size, ...)` to `range(0, args.num_points, ...)`
- This ensures all data points are processed regardless of the number of batches

## Testing
- Verified with `num_batch = 1`: All data processed
- Verified with `num_batch = 2`: All 40 points processed correctly
- No regression in existing functionality

## Related Issue
Fixes #1

---

### Code Change
**Before:**
```python
for i in range(0, args.batch_size, args.batch_size_per_inference):
    # Only iterates up to batch_size (up to 20)
```

**After:**
```python
for i in range(0, args.num_points, args.batch_size_per_inference):
    # Should iterate up to num_points (up to 40)
```